### PR TITLE
make sbd_is_disk not static so it can be referenced by sbd-md.c

### DIFF
--- a/src/sbd-inquisitor.c
+++ b/src/sbd-inquisitor.c
@@ -34,7 +34,7 @@ char*	pidfile = NULL;
 
 int parse_device_line(const char *line);
 
-static bool
+bool
 sbd_is_disk(struct servants_list_item *servant) 
 {
     if (servant == NULL

--- a/src/sbd.h
+++ b/src/sbd.h
@@ -189,4 +189,4 @@ void set_proc_title(const char *fmt,...);
 extern int servant_health;
 void set_servant_health(enum pcmk_health state, int level, char const *format, ...) __attribute__ ((__format__ (__printf__, 3, 4)));
 
-bool sbd_is_disk(struct servants_list_item *servant) 
+bool sbd_is_disk(struct servants_list_item *servant);

--- a/src/sbd.h
+++ b/src/sbd.h
@@ -188,3 +188,5 @@ void set_proc_title(const char *fmt,...);
 
 extern int servant_health;
 void set_servant_health(enum pcmk_health state, int level, char const *format, ...) __attribute__ ((__format__ (__printf__, 3, 4)));
+
+bool sbd_is_disk(struct servants_list_item *servant) 


### PR DESCRIPTION
I'm not sure if this is a/the desirable fix, but without it I was getting "undefined reference to `sbd_is_disk'" errors from sbd-md.c on lines 823 and 836.
